### PR TITLE
Generate bibliography from biblio.bib instead of hardcoding the entries at the end

### DIFF
--- a/vignettes/BETS_basic_usage.Rmd
+++ b/vignettes/BETS_basic_usage.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "BETS - Brazilian Economic Time Series: Basic Usage"
-bibliography: 
+bibliography: biblio.bib
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
@@ -335,7 +335,3 @@ informative.
 
 
 ## References 
-
-Ooms, J., D. James, S. DebRoy, H. Wickham, and J. Horner. 2016. RMySQL: Database Interface and Mysql Driver for R. https://cran.r-project.org/package=RMySQL.
-
-R Core Team. 2012. R: A Language and Environment for Statistical Computing. Vienna, Austria: R Foundation for Statistical Computing. https://www.R-project.org/.

--- a/vignettes/BETS_basic_usage.Rmd
+++ b/vignettes/BETS_basic_usage.Rmd
@@ -4,7 +4,7 @@ bibliography: biblio.bib
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{"BETS - Brazilian Economic Time Series: Basic Usage""}
+  %\VignetteIndexEntry{BETS - Brazilian Economic Time Series: Basic Usage}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---


### PR DESCRIPTION
Currently the `bibliography` field is empty, which will trigger an error in a future version of **rmarkdown**. We'll truly appreciate it if you could merge this PR and make a CRAN release in the near future. Thank you!